### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://jjtopman.visualstudio.com/7f6300c0-b0cd-4640-bfb9-ea7df5166e3b/ee656a57-ab72-44da-8753-c2f42534f185/_apis/work/boardbadge/e1e3bd41-4000-4336-bb80-81c662d5a9e3)](https://jjtopman.visualstudio.com/7f6300c0-b0cd-4640-bfb9-ea7df5166e3b/_boards/board/t/ee656a57-ab72-44da-8753-c2f42534f185/Microsoft.RequirementCategory)
 # Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#463](https://jjtopman.visualstudio.com/7f6300c0-b0cd-4640-bfb9-ea7df5166e3b/_workitems/edit/463). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.